### PR TITLE
Add service logos as responsive cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,40 @@
         </div>
       </div>
     </nav>
-    <div class="container" style="padding-top: 4rem;">
-      <main class="d-flex">
-        <img src="src/images/logo.png" class="img-fluid mx-auto d-block" alt="GrimmSaunders LLC logo" />
-      </main>
+      <div class="container" style="padding-top: 4rem;">
+        <main class="d-flex flex-column align-items-center">
+          <img src="src/images/logo.png" class="img-fluid mx-auto d-block mb-4" alt="GrimmSaunders LLC logo" />
+
+          <div class="row row-cols-1 row-cols-md-3 g-4 w-100">
+            <div class="col">
+              <div class="card h-100 text-center">
+                <img src="src/images/perfectPixels-logo.png" class="card-img-top rounded" alt="Pristine Pixels logo">
+                <div class="card-body">
+                  <h5 class="card-title">Pristine Pixels</h5>
+                  <p class="card-text">Our designers actually know when to stop using Comic Sans.</p>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="card h-100 text-center">
+                <img src="src/images/parcels-logo.png" class="card-img-top rounded" alt="Parcels logo">
+                <div class="card-body">
+                  <h5 class="card-title">Parcels</h5>
+                  <p class="card-text">Delivering packages faster than you can say "tracking number".</p>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="card h-100 text-center">
+                <img src="src/images/itServices-logo.png" class="card-img-top rounded" alt="IT Services logo">
+                <div class="card-body">
+                  <h5 class="card-title">IT Services</h5>
+                  <p class="card-text">We fix your tech nightmares so you don't smash the keyboard.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
 
     <footer class="footer mt-auto py-3 bg-light">
       <div class="container text-center">


### PR DESCRIPTION
## Summary
- show off Pristine Pixels, Parcels, and IT Services as Bootstrap cards on the homepage

## Testing
- `npx sass --silence-deprecation=mixed-decls ./src/scss/styles.scss ./src/css/styles.css`

------
https://chatgpt.com/codex/tasks/task_e_68472a37c05c832b90f244145be5d04b